### PR TITLE
Fix reassigned path library with path string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,8 @@ import json
 # modify default service file
 
 service = os.popen("cat tallycoin_connect.service").read();
-path = os.getcwd()
-new_service = service.replace("{{working_directory}}", path);
+cwd = os.getcwd()
+new_service = service.replace("{{working_directory}}", cwd);
 
 # save service file
 


### PR DESCRIPTION
While running setup.py I was getting error:
```
Traceback (most recent call last):
  File "setup.py", line 33, in <module>
    if path.exists("tallycoin_api.key"):
AttributeError: 'str' object has no attribute 'exists'
```

Path library is getting reassigned to cwd string.