### PR TITLE
Publish tags on Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,93 @@
+version: 2
+jobs:
+  # Define in CircleCi Project Variables: $DOCKERHUB_REPO, $DOCKERHUB_USER, $DOCKERHUB_PASS
+  # Publish jobs require those variables
+  amd64:
+    machine:
+      enabled: true
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker build --pull -t "$DOCKERHUB_REPO:$CIRCLE_TAG-amd64" -f Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push "$DOCKERHUB_REPO:$CIRCLE_TAG-amd64"
+  arm32v7:
+    machine:
+      enabled: true
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            #
+            sudo docker build --pull -t "$DOCKERHUB_REPO:$CIRCLE_TAG-arm32v7" -f Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push "$DOCKERHUB_REPO:$CIRCLE_TAG-arm32v7"
+  arm64v8:
+    machine:
+      enabled: true
+      image: ubuntu-2004:202101-01
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
+            #
+            sudo docker build --pull -t "$DOCKERHUB_REPO:$CIRCLE_TAG-arm64v8" -f Dockerfile .
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            sudo docker push "$DOCKERHUB_REPO:$CIRCLE_TAG-arm64v8"
+  multiarch:
+    machine:
+      enabled: true
+      image: circleci/classic:201808-01
+    steps:
+      - run:
+          command: |
+            # Turn on Experimental features
+            sudo mkdir $HOME/.docker
+            sudo sh -c 'echo "{ \"experimental\": \"enabled\" }" >> $HOME/.docker/config.json'
+            #
+            sudo docker login --username=$DOCKERHUB_USER --password=$DOCKERHUB_PASS
+            #
+            sudo docker manifest create --amend "$DOCKERHUB_REPO:$CIRCLE_TAG" "$DOCKERHUB_REPO:$CIRCLE_TAG-amd64" "$DOCKERHUB_REPO:$CIRCLE_TAG-arm32v7" "$DOCKERHUB_REPO:$CIRCLE_TAG-arm64v8"
+            sudo docker manifest annotate "$DOCKERHUB_REPO:$CIRCLE_TAG" "$DOCKERHUB_REPO:$CIRCLE_TAG-amd64" --os linux --arch amd64
+            sudo docker manifest annotate "$DOCKERHUB_REPO:$CIRCLE_TAG" "$DOCKERHUB_REPO:$CIRCLE_TAG-arm32v7" --os linux --arch arm --variant v7
+            sudo docker manifest annotate "$DOCKERHUB_REPO:$CIRCLE_TAG" "$DOCKERHUB_REPO:$CIRCLE_TAG-arm64v8" --os linux --arch arm64 --variant v8
+            sudo docker manifest push "$DOCKERHUB_REPO:$CIRCLE_TAG" -p
+
+workflows:
+  version: 2
+  publish:
+    jobs:
+      - amd64:
+          filters:
+            # ignore any commit on any branch by default
+            branches:
+              ignore: /.*/
+            # only act on version tags
+            tags:
+              only: /(v[1-9]+(\.[0-9]+)*(-[a-z0-9-]+)?)|(v[a-z0-9-]+)/
+      - arm32v7:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /(v[1-9]+(\.[0-9]+)*(-[a-z0-9-]+)?)|(v[a-z0-9-]+)/
+      - arm64v8:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /(v[1-9]+(\.[0-9]+)*(-[a-z0-9-]+)?)|(v[a-z0-9-]+)/
+      - multiarch:
+          requires:
+            - amd64
+            - arm32v7
+            - arm64v8
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /(v[1-9]+(\.[0-9]+)*(-[a-z0-9-]+)?)|(v[a-z0-9-]+)/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.circleci
+.env*
+.git
+.gitignore
+*.md
+!README.md
+node_modules
+setup.py
+tallycoin_api.key
+tallycoin_connect.service


### PR DESCRIPTION
Adds the CircleCI config to automatically publish git tags as releases on Docker Hub.

I have added this for [my own fork](https://hub.docker.com/r/dennisreimann/tallycoin_connect/tags?page=1&ordering=last_updated), which I'd like to eliminate in favor of official releases from this repo.

In order to set this up, you'd need a CircleCI and a Docker Hub account. The project can be added on Circle CI and Dockerhub -- the three env vars need to be provided in CircleCI to make it work:

-  `DOCKERHUB_USER=djbooth007` 
-  `DOCKERHUB_REPO=tallycoin_connect` 
-  `DOCKERHUB_PASS` is an [Docker Hub access token](https://hub.docker.com/settings/security)

Let me know if I should assist getting this done :) 